### PR TITLE
MAKER-429 Platform.txt point to correct toolchain location

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -5,10 +5,10 @@
 name=Arduino i586 Boards
 # compiler.path TBD
 compiler.pre_install.cmd.linux=tools/i586/install_script.sh
-compiler.path={runtime.ide.path}/hardware/tools/i586/pokysdk/usr/bin/i586-poky-linux-uclibc/
-compiler.path.linux={runtime.ide.path}/hardware/tools/i586/sysroots/pokysdk/usr/bin/i586-poky-linux-uclibc/
-compiler.sysroot={runtime.ide.path}/hardware/tools/i586/i586-poky-linux-uclibc
-compiler.sysroot.linux={runtime.ide.path}/hardware/tools/i586/sysroots/i586-poky-linux-uclibc
+compiler.path={runtime.tools.i586-poky-linux-uclibc-1.0.4.path}/pokysdk/usr/bin/i586-poky-linux-uclibc/
+compiler.path.linux={runtime.tools.i586-poky-linux-uclibc-1.0.4.path}/sysroots/pokysdk/usr/bin/i586-poky-linux-uclibc/
+compiler.sysroot={runtime.tools.i586-poky-linux-uclibc-1.0.4.path}/i586-poky-linux-uclibc
+compiler.sysroot.linux={runtime.tools.i586-poky-linux-uclibc-1.0.4.path}sysroots/i586-poky-linux-uclibc
 compiler.prefix=i586-poky-linux-uclibc
 compiler.c.cmd={compiler.prefix}-gcc
 compiler.c.flags= -m32 -march=i586 "--sysroot={compiler.sysroot}" -c -g -Os -w -ffunction-sections -fdata-sections -MMD -D__ARDUINO_X86__ -Xassembler -mquark-strip-lock=yes


### PR DESCRIPTION
1.6.1 installs toolchain in a different location. Platform file needs to
reference to location where it is installed.
