### PR TITLE
Add keywords.txt to Wire library

### DIFF
--- a/libraries/Wire/keywords.txt
+++ b/libraries/Wire/keywords.txt
@@ -1,0 +1,30 @@
+#######################################
+# Syntax Coloring Map For Wire
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+begin	KEYWORD2
+beginTransmission	KEYWORD2
+endTransmission	KEYWORD2
+requestFrom	KEYWORD2
+onReceive	KEYWORD2
+onRequest	KEYWORD2
+
+#######################################
+# Instances (KEYWORD2)
+#######################################
+
+Wire	KEYWORD2
+Wire1	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+


### PR DESCRIPTION
Provides syntax highlighting of Wire library specific keywords.
