### PR TITLE
Unique Built-In libraries library.properties name

### DIFF
--- a/libraries/Ethernet/library.properties
+++ b/libraries/Ethernet/library.properties
@@ -1,4 +1,4 @@
-name=Ethernet
+name=Ethernet(Galileo)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/SD/library.properties
+++ b/libraries/SD/library.properties
@@ -1,4 +1,4 @@
-name=SD
+name=SD(Galileo)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/Servo/library.properties
+++ b/libraries/Servo/library.properties
@@ -1,4 +1,4 @@
-name=Servo
+name=Servo(Galileo)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/WiFi/library.properties
+++ b/libraries/WiFi/library.properties
@@ -1,4 +1,4 @@
-name=WiFi
+name=WiFi(Galileo)
 version=1.0
 author=Intel
 maintainer=Intel


### PR DESCRIPTION
Use unique name values in library.properties for the Galileo libraries
that are also Arduino IDE Built-In libraries. This solves the issue of
SD, Servo, and Wifi libraries always appearing as Type: Updatable in the
Arduino IDE 1.6.6 Library Manager when a Galileo board is selected.
