### PR TITLE
Non-Built-In libs unique library.properties name

### DIFF
--- a/libraries/DallasTemperature/library.properties
+++ b/libraries/DallasTemperature/library.properties
@@ -1,4 +1,4 @@
-name=DallasTemperature
+name=DallasTemperature(Galileo)
 version=1.0
 author=*
 maintainer=*

--- a/libraries/OneWire/library.properties
+++ b/libraries/OneWire/library.properties
@@ -1,4 +1,4 @@
-name=OneWire
+name=OneWire(Galileo)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/TimerOne/library.properties
+++ b/libraries/TimerOne/library.properties
@@ -1,4 +1,4 @@
-name=TimerOne
+name=TimerOne(Galileo)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/USBHost/library.properties
+++ b/libraries/USBHost/library.properties
@@ -1,4 +1,4 @@
-name=USBHost
+name=USBHost(Galileo)
 version=1.0
 author=Intel
 maintainer=Intel


### PR DESCRIPTION
Change to unique name values in library.properties for all non-Built-In
libraries that are in the Arduino IDE Library Manager. This will reduce
the occurrence of Library Manager updates of the non-Galileo library
versions causing them to override the Galileo versions. Note that this
will not solve the override issue. See
https://github.com/arduino/Arduino/issues/4064 for more information on
this issue.

Although the changes made are the same(but for different libraries) as https://github.com/01org/corelibs-galileo/pull/16 I have created this as a separate pull request because it addresses a different issue. The Arduino IDE Library Manager installs library updates to the `libraries` folder inside of the sketchbook folder. Libraries in this folder override all other libraries, including the Galileo libraries. If there is a newer Non-Galileo version of one the the Galileo libraries available in Library Manager then Arduino IDE 1.6.6 will show an update notification which will likely cause the user to make the update. By changing the name in `library.properties` this notification is avoided although the override will still occur if the user installs the non-Galileo version of any of the Galileo libraries to the `libraries` folder in their sketchbook with or without Library Manager.
