### PR TITLE
MAKER-530 Architectures field wrongly declared

### DIFF
--- a/libraries/DallasTemperature/library.properties
+++ b/libraries/DallasTemperature/library.properties
@@ -6,5 +6,5 @@ sentence=DallasTemperature library
 paragraph=DallasTemperature library
 category=Sensors
 url=http://makers.intel.com
-architectures=i586-uclibc
+architectures=i586
 core-dependencies=arduino (>=1.5.0)

--- a/libraries/EEPROM/library.properties
+++ b/libraries/EEPROM/library.properties
@@ -6,5 +6,5 @@ sentence=Intel EEPROM library
 paragraph=Intel EEPROM library
 category=Data Storage
 url=http://makers.intel.com
-architectures=i586-uclibc
+architectures=i586
 core-dependencies=arduino (>=1.5.0)

--- a/libraries/Ethernet/library.properties
+++ b/libraries/Ethernet/library.properties
@@ -6,5 +6,5 @@ sentence=Enables network connection (local and Internet) using the onboard ether
 paragraph=With this library you can use the onboard ethernet to connect to Internet. The library provides both Client and server functionalities. The library permits you to connect to a local network also with DHCP and to resolve DNS.
 category=Communication
 url=http://arduino.cc/en/Reference/Ethernet
-architectures=i586-uclibc
+architectures=i586
 core-dependencies=arduino (>=1.5.0)

--- a/libraries/OneWire/library.properties
+++ b/libraries/OneWire/library.properties
@@ -6,5 +6,5 @@ sentence=Intel OneWirelibrary
 paragraph=Intel OneWire library
 category=Communication
 url=http://makers.intel.com
-architectures=i585-uclibc
+architectures=i586
 core-dependencies=arduino (>=1.5.0)

--- a/libraries/SD/library.properties
+++ b/libraries/SD/library.properties
@@ -7,5 +7,5 @@ sentence=The libary to use the onboard SD slot on the Intel Galileo and Galileo 
 paragraph=With this library you can use the onboard SD slot of the Intel Galileo and Galileo Gen2
 category=Data Storage
 url=http://arduino.cc/en/Reference/SD
-architectures=i586-uclibc
+architectures=i586
 core-dependencies=arduino (>=1.5.0)

--- a/libraries/SPI/library.properties
+++ b/libraries/SPI/library.properties
@@ -6,4 +6,4 @@ sentence=SPI library for Intel Galileo and Galileo Gen2.
 paragraph=SPI library for Intel Galileo and Galileo Gen2.
 category=Communication
 url=http://arduino.cc/en/Reference/SPI
-architectures=*
+architectures=i586

--- a/libraries/Servo/library.properties
+++ b/libraries/Servo/library.properties
@@ -8,5 +8,5 @@ paragraph=Supports Galileo Gen1 and Gen2
 category=Device Control
 url=http://arduino.cc/en/Reference/Servo
 dependencies=Wire
-architectures=i586-uclibc
+architectures=i586
 core-dependencies=arduino (>=1.5.0)

--- a/libraries/TimerOne/library.properties
+++ b/libraries/TimerOne/library.properties
@@ -6,5 +6,5 @@ sentence=Intel TimerOne library
 paragraph=Intel TimerOne library
 category=Timing
 url=http://makers.intel.com
-architectures=i585-uclibc
+architectures=i586
 core-dependencies=arduino (>=1.5.0)

--- a/libraries/USBHost/library.properties
+++ b/libraries/USBHost/library.properties
@@ -6,5 +6,5 @@ sentence=USBHost library
 paragraph=USBHost library
 category=Other
 url=http://arduino.cc/en/Reference/USBHost
-architectures=i586-uclibc
+architectures=i586
 core-dependencies=arduino (>=1.5.0)

--- a/libraries/WiFi/library.properties
+++ b/libraries/WiFi/library.properties
@@ -6,5 +6,5 @@ sentence=Enables network connection (local and Internet) using the Intel Centrin
 paragraph=With this library you can instantiate Servers, Clients and send/receive UDP packets through WiFi. The shield can connect either to open or encrypted networks (WEP, WPA). The IP address can be assigned statically or through a DHCP. The library can also manage DNS.
 category=Communication
 url=http://arduino.cc/en/Reference/WiFi
-architectures=i586-uclibc
+architectures=i586
 core-dependencies=arduino (>=1.5.0)

--- a/libraries/Wire/library.properties
+++ b/libraries/Wire/library.properties
@@ -7,5 +7,5 @@ sentence=Intel Galileo Wire library
 paragraph=Supports Galileo Gen1 and Gen2
 category=Communication
 url=http://makers.intel.com
-architectures=i586-uclibc
+architectures=i586
 core-dependencies=arduino (>=1.5.0)


### PR DESCRIPTION
Architectures field wrongly declared for Galileo in the
library.properties file for all custom libraries
i586-uclibc should be i586
