### PR TITLE
updated libraries naming and set right arch for EthernetShield

### DIFF
--- a/libraries/DallasTemperature/library.properties
+++ b/libraries/DallasTemperature/library.properties
@@ -1,4 +1,4 @@
-name=DallasTemperature(Galileo)
+name=DallasTemperature
 version=1.0
 author=*
 maintainer=*

--- a/libraries/Ethernet/library.properties
+++ b/libraries/Ethernet/library.properties
@@ -1,4 +1,4 @@
-name=Ethernet(Galileo)
+name=Ethernet
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/EthernetShield/library.properties
+++ b/libraries/EthernetShield/library.properties
@@ -5,7 +5,7 @@ sentence=The libary to use the Arduino Ethernet shield or the Arduino Ethernet b
 paragraph=With this library you can use the Arduino Ethernet (shield or board) to connect to Internet. The library provides both Client and server functionalities. The library permits you to connect to a local network also with DHCP and to resolve DNS.
 category=Communication
 url=http://arduino.cc/en/Reference/Ethernet
-architectures=*
+architectures=i586
 version=1.0
 dependencies=SPI
 core-dependencies=arduino (>=1.5.0)

--- a/libraries/OneWire/library.properties
+++ b/libraries/OneWire/library.properties
@@ -1,4 +1,4 @@
-name=OneWire(Galileo)
+name=OneWire
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/SD/library.properties
+++ b/libraries/SD/library.properties
@@ -1,4 +1,4 @@
-name=SD(Galileo)
+name=SD
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/Servo/library.properties
+++ b/libraries/Servo/library.properties
@@ -1,4 +1,4 @@
-name=Servo(Galileo)
+name=Servo
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/TimerOne/library.properties
+++ b/libraries/TimerOne/library.properties
@@ -1,4 +1,4 @@
-name=TimerOne(Galileo)
+name=TimerOne
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/USBHost/library.properties
+++ b/libraries/USBHost/library.properties
@@ -1,4 +1,4 @@
-name=USBHost(Galileo)
+name=USBHost
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/WiFi/library.properties
+++ b/libraries/WiFi/library.properties
@@ -1,4 +1,4 @@
-name=WiFi(Galileo)
+name=WiFi
 version=1.0
 author=Intel
 maintainer=Intel


### PR DESCRIPTION
Similarly to https://github.com/01org/corelibs-edison/pull/23

We have a filtering system in place on the Arduino IDEs (and specifically on the Arduino Create IDE) based on the architecture, so there is no need to specify the board name in the library name :)

Also the EthernetShield had the wrong architecture tag.
@facchinm
