### PR TITLE
Fix compile error with Serial.write(arg1, arg2)

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -39,6 +39,15 @@ size_t Print::write(const uint8_t *buffer, size_t size)
   return n;
 }
 
+size_t Print::write(const char *buffer, size_t size)
+{
+  size_t n = 0;
+  while (size--) {
+    n += write(*buffer++);
+  }
+  return n;
+}
+
 size_t Print::print(const __FlashStringHelper *ifsh)
 {
   return print(reinterpret_cast<const char *>(ifsh));

--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -51,6 +51,8 @@ class Print
       return write((const uint8_t *)str, strlen(str));
     }
     virtual size_t write(const uint8_t *buffer, size_t size);
+    
+    virtual size_t write(const char *buffer, size_t size);
 
     size_t print(const __FlashStringHelper *);
     size_t print(const String &);


### PR DESCRIPTION
-Allows the first arg of Serial.write(arg1, arg2) to be of type const
char*
