### PR TITLE
Add missing functions to String Class

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -29,7 +29,7 @@
 
 #include "WString.h"
 #include <stdio.h>
-
+#include <avr/dtostrf.h>
 
 // following the C++ standard operators with attributes in right
 // side must be defined globally
@@ -165,6 +165,40 @@ String::String(unsigned long value, unsigned char base)
 	//ultoa(value, buf, base);
 	snprintf(buf, sizeof(buf), getCSpec(base, false, true), value);
 	*this = buf;
+}
+
+String::String(float value, unsigned char decimalPlaces)
+{
+	init();
+    int digits = 0;
+    int intValue = (int)value;
+    while(intValue !=0)
+    {
+        intValue /= 10;
+        digits++;
+    }
+    digits += + decimalPlaces;
+    if(value < 0)
+        digits++;
+	char buf[digits];
+	*this = dtostrf(value, digits, decimalPlaces, buf);
+}
+
+String::String(double value, unsigned char decimalPlaces)
+{
+	init();
+    int digits = 0;
+    int intValue = (int)value;
+    while(intValue !=0)
+    {
+        intValue /= 10;
+        digits++;
+    }
+    digits += + decimalPlaces;
+    if(value < 0)
+        digits++;
+	char buf[digits];
+	*this = dtostrf(value, digits, decimalPlaces, buf);
 }
 
 String::~String()

--- a/cores/arduino/WString.h
+++ b/cores/arduino/WString.h
@@ -72,6 +72,8 @@ public:
 	explicit String(unsigned int, unsigned char base=10);
 	explicit String(long, unsigned char base=10);
 	explicit String(unsigned long, unsigned char base=10);
+	explicit String(float, unsigned char decimalPlaces=2);
+	explicit String(double, unsigned char decimalPlaces=2);
 	~String(void);
 
 	// memory management

--- a/cores/arduino/avr/dtostrf.c
+++ b/cores/arduino/avr/dtostrf.c
@@ -1,0 +1,23 @@
+/*
+  dtostrf - Emulation for dtostrf function from avr-libc
+  Copyright (c) 2013 Arduino.  All rights reserved.
+  Written by Cristian Maglie <c.maglie@bug.st>
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+char *dtostrf (double val, signed char width, unsigned char prec, char *sout) {
+  char fmt[20];
+  sprintf(fmt, "%%%d.%df", width, prec);
+  sprintf(sout, fmt, val);
+  return sout;
+}

--- a/cores/arduino/avr/dtostrf.h
+++ b/cores/arduino/avr/dtostrf.h
@@ -1,0 +1,26 @@
+/*
+  dtostrf - Emulation for dtostrf function from avr-libc
+  Copyright (c) 2013 Arduino.  All rights reserved.
+  Written by Cristian Maglie <c.maglie@bug.st>
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char *dtostrf (double val, signed char width, unsigned char prec, char *sout);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
-String class was missing some functions causing the StringConstuctors
example to fail compiling
-also added dtostrf emulation
