### PR TITLE
Add String::c_str()

### DIFF
--- a/cores/arduino/WString.h
+++ b/cores/arduino/WString.h
@@ -166,6 +166,7 @@ public:
 	void getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index=0) const;
 	void toCharArray(char *buf, unsigned int bufsize, unsigned int index=0) const
 		{getBytes((unsigned char *)buf, bufsize, index);}
+	const char * c_str() const { return buffer; }
 
 	// search
 	int indexOf( char ch ) const;


### PR DESCRIPTION
WString is out of sync with official Arduino implementation.
See [similar Pull Request #18 on corelibs-edison](https://github.com/01org/corelibs-edison/pull/18/).
See [Issue #299 of ArduinoJson](https://github.com/bblanchon/ArduinoJson/issues/299).
